### PR TITLE
Fix: remove typos from page generator - fixes #184

### DIFF
--- a/config/generators/page/README.md.hbs
+++ b/config/generators/page/README.md.hbs
@@ -2,7 +2,7 @@
 A top level page container that corresponds to a route by the same name.
 
 ### Route Parameters
-An paramaters that might be part of the route.
+Any parameters that might be part of the route.
 
 ### Example Usage
 


### PR DESCRIPTION
Remove the typos from page generator so new pages will not have
typos.